### PR TITLE
add explicit case for zero in double/int source columns to sanitizeValue function

### DIFF
--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -483,6 +483,8 @@ class FromMySqlToPostgreSql
     private function sanitizeValue($strValue)
     {
         switch ($strValue) {
+            case '0':
+                return '0';
             case '0000-00-00 00:00:00':
             case '0000-00-00':
                 return '-INFINITY';


### PR DESCRIPTION
Without this case, if double or integer columns in my source MySQL
database have zero as a default value, rows where the column is not
changed from the default seem to be interpreted by the santize
function as timestamps, and then I have "-INFINITY" showing up
throughout the intermediate generate .csv file. This causes column
type errors when trying to insert into the Postgres table. Moreover,
this puts the whole script into an infinite loop it seems -- I
finally terminated it after about 15 minutes and after the log files
grew to 6 gigabytes (at this stage only one table was ever created,
and no rows were inserted into it).

The majority of the errors are repetition of these,
particularly the second one in a seemingly infinite loop:

    -- FromMySqlToPostgreSql::populateTable
    -- PDOException code: 22P02
    -- File: /path/to/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
    -- Line: 680
    -- Message:
       SQLSTATE[22P02]: Invalid text representation: 7
       ERROR:  invalid input syntax for integer: "-INFINITY"
       CONTEXT:  COPY first_table, line 1, column some_integer_column: "-INFINITY"
    -- SQL: COPY "public"."first_table" FROM '/path/to/temporary_directory/first_table.csv' DELIMITER ',' CSV;

    -------------------------------------------------------

    -- FromMySqlToPostgreSql::populateTableByPrepStmtWorker
    -- PDOException code: HY093
    -- File: /path/tp/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
    -- Line: 540
    -- Message: SQLSTATE[HY093]: Invalid parameter number: :some_double_column

After adding this case, the script continues on to creating other
tables, and inserts rows of data successfully. It completes in perhaps
under a minute.

Tested with:
    PHP 5.6.13
    10.0.21-MariaDB-log MariaDB Server
    PostgreSQL 9.4.4