### PR TITLE
Fixed MySQL encoding problem

### DIFF
--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -282,7 +282,7 @@ class FromMySqlToPostgreSql
     {
         if (empty($this->mysql)) {
             $arrSrcInput = explode(',', $this->strSourceConString);
-            $this->mysql = new \PDO($arrSrcInput[0], $arrSrcInput[1], $arrSrcInput[2]);
+            $this->mysql = new \PDO($arrSrcInput[0], $arrSrcInput[1], $arrSrcInput[2], array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
             $this->mysql->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
             $this->mysql->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         }


### PR DESCRIPTION
Using the default Encoding for MySQL didn't work. Therefore I changed the code to always use UTF-8 on the MySQL side.

This allowed me to correctly import data containing UTF-8 encoded text.