### PR TITLE
Fix bigint unsigned and bit handling

### DIFF
--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -578,7 +578,11 @@ class FromMySqlToPostgreSql
             case '0000-00-00':
             case '0000-00-00 00:00:00':
                 return '-INFINITY';
-            
+
+            case chr(0): return '0';
+
+            case chr(1): return '1';
+
             default:
                 return $strValue;
         }

--- a/migration/FromMySqlToPostgreSql/MapDataTypes.php
+++ b/migration/FromMySqlToPostgreSql/MapDataTypes.php
@@ -79,7 +79,7 @@ class MapDataTypes
         ],
         
         'bigint' => [
-            'increased_size'           => 'bigint', 
+            'increased_size'           => 'numeric(20)',
             'type'                     => 'bigint',
             'mySqlVarLenPgSqlFixedLen' => true,
         ],


### PR DESCRIPTION
Hi, 
thank you for this extremely helpful project!
The changes in this pull request helped us to fix the following issues when migrating our database:

* Bits could not be migrated because they where written as ascii code 0 and 1 to the migration csv file
* bigint unsigned did not fit into postgres bigint tables, numeric(20) did the job for us

Maybe those changes are useful for others too.