### PR TITLE
Allow user to choose which tables/views to migrate

### DIFF
--- a/index.php
+++ b/index.php
@@ -94,7 +94,9 @@ if (empty($arrConfig)) {
     
     $arrConfig['temp_dir_path'] = __DIR__ . '/temporary_directory';
     $arrConfig['logs_dir_path'] = __DIR__ . '/logs_directory';
-    
+    if (!empty(@trim($arrConfig['source_objects']))) {
+        $arrConfig['source_objects'] = explode(',', trim($arrConfig['source_objects']));
+    }
     $migration = new \FromMySqlToPostgreSql($arrConfig);
     $migration->migrate();
 }

--- a/sample_config.json
+++ b/sample_config.json
@@ -5,7 +5,14 @@
         "Ensure, that details like 'charset=UTF8' are included in your connection string (if necessary)."
     ],
     "source" : "mysql:host=localhost;port=3306;charset=UTF8;dbname=your_db_name,your_user_name,your_password",
-    
+
+    "source_objects_description" : [
+    	"The table and view names you want to migrate",
+        "Should be an array of string",
+        "If empty, all tables and views will be migrated."
+    ],
+    "source_objects" : [],
+
     "target_description" : [
         "Connection string to your PostgreSql database",
         "Please ensure, that you have defined your connection string properly.",

--- a/sample_config.xml
+++ b/sample_config.xml
@@ -1,35 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
-    <!-- 
-        <source> - a connection string to your MySql database. 
+    <!--
+        <source> - a connection string to your MySql database.
         Please ensure, that you have defined your connection string properly.
         Ensure, that details like 'charset=UTF8' are included in your connection string (if necessary).
     -->
     <source>mysql:host=localhost;port=3306;dbname=your_db_name;charset=UTF8,your_user_name,your_password</source>
+
+    <!--
+        <source_objects> - the tables and views you want to migrate.
+        Should be a string with each name separated by comma, e.g., table1,table2,view1,view2.
+        If empty, all tables and views will be migrated.
+    -->
+    <source_objects>table1,table2</source_objects>
     
-    <!-- 
-        <target> - a connection string to your PostgreSql database. 
+    <!--
+        <target> - a connection string to your PostgreSql database.
         Please ensure, that you have defined your connection string properly.
         Ensure, that details like options='[double dash]client_encoding=UTF8' are included in your connection string (if necessary).
     -->
     <target>pgsql:host=localhost;port=5432;dbname=your_pg_db_name;options=--client_encoding=UTF8,your_user_name,your_password</target>
-    
-    <!-- 
-        <encoding> - PHP encoding type. 
-        If not supplied, then UTF-8 will be used as a default. 
+
+    <!--
+        <encoding> - PHP encoding type.
+        If not supplied, then UTF-8 will be used as a default.
     -->
     <encoding>UTF-8</encoding>
-    
+
     <!--
         <schema> - a name of the schema, that will contain all migrated tables.
         If not supplied, then a new schema will be created automatically.
     -->
     <schema></schema>
-    
+
     <!--
         During migration each table's data will be split into chunks of <data_chunk_size> (in MB).
         If not supplied, then 10 MB will be used as a default.
     -->
     <data_chunk_size>10</data_chunk_size>
 </root>
-


### PR DESCRIPTION
Add a parameter "source_objects" to allow user to choose which tables/views to migrate (if empty, means all tables/views).
Because sometimes people maybe don't want to migrate the whole database but only part of it.