### PR TITLE
Makes public the default schema

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -21,9 +21,10 @@
     
     "schema_description" : [
         "schema - a name of the schema, that will contain all migrated tables.",
+        "Default is 'public', which will cause the new tables to appear at the top level of the database defined above in 'target'",
         "If not supplied, then a new schema will be created automatically."
     ],
-    "schema" : "",
+    "schema" : "public",
     
     "data_chunk_size_description" : [
         "During migration each table's data will be split into chunks of data_chunk_size (in MB).",


### PR DESCRIPTION
A newer user of postgres may not be aware of the schema behavior. This changes the default schema to 'public' so the new tables appear at the top level of the target database.

I believe this is a more expected behavior.