### PR TITLE
Efficiency and bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,16 @@ The chunk size can be adjusted easily via configuration file.</li>
 <p>Current version is 1.4.2<br />
 (major version . improvements . bug fixes)</p>
 
+<h3>TESTING</h3>
+<p>The tests/ folder contains SQL files that exercise the migration tool to ensure it can
+process different types of input structures correctly.  To use these files you must
+setup a mysql server with them. An example might be <code>mysql < tests/foreign_key.sql</code>.
+You can then follow the use the USAGE section to create a migration script it runs without error.
+If you wish to add further tests to verify issues that are fixed, just add another SQL file
+and future developers will be able to confirm that changes don't cause any regressions.
+</p>
 
-<h3>TEST</h3>
+<h3>PERFORMANCE RESULTS</h3>
 <p>Tested using MySql Community Server (5.6.21) and PostgreSql (9.3).<br />
 The entire process of migration 59.6 MB database (49 tables, 570750 rows),<br /> 
 which includes data types mapping, creation of tables, constraints, indexes, <br />

--- a/README.md
+++ b/README.md
@@ -98,15 +98,11 @@ and future developers will be able to confirm that changes don't cause any regre
 </p>
 
 <h3>PERFORMANCE RESULTS</h3>
-<p>Tested using MySql Community Server (5.6.21) and PostgreSql (9.3).<br />
-The entire process of migration 59.6 MB database (49 tables, 570750 rows),<br /> 
+<p>Tested using MariaDB 10 and PostgreSql (9.6).<br />
+The entire process of migration 33Gb MB database (90 tables, approximately 72 million rows),<br />
 which includes data types mapping, creation of tables, constraints, indexes, <br />
 PKs, FKs, migration of data, garbage-collection and analyzing the newly created <br />
-PostgreSql database took 3 minutes 6 seconds.</p>
-<p>Tested using MySql Community Server (5.6.21) and PostgreSql (9.4).<br />
-The entire process of migration 3.1 GB database (56 tables, 8732967 rows),<br /> 
-with the same steps as above, took 2 hours and 10 minutes.</p> 
-
+PostgreSql database took 54 minutes.</p>
 
 <h3>LICENSE</h3>
 <p>FromMySqlToPostgreSql is available under "GNU GENERAL PUBLIC LICENSE" (v. 3) <br />

--- a/index.php
+++ b/index.php
@@ -80,6 +80,27 @@ function getConfig($strPath)
     return $arrRetVal;
 }
 
+// Verify the extensions are loaded before running.
+if (!extension_loaded('pgsql')) {
+    echo "Postgresql not enabled: you need the 'pgsql' module.\n";
+    exit(1);
+}
+if (!extension_loaded('pdo_mysql')) {
+    echo "Postgresql not enabled: you need the 'pdo_mysql' module.\n";
+    exit(1);
+}
+if (!extension_loaded('pdo_pgsql')) {
+    echo "Postgresql not enabled: you need the 'pdo_pgsql' module.\n";
+    exit(1);
+}
+if (!extension_loaded('mbstring')) {
+    echo "Multibyte extension not loaded: you need the 'mbstring' module.\n";
+    exit(1);
+}
+if (ini_get('register_argc_argv') == 0) {
+    echo "register_argc_argv is not turned on, we can't process command line arguments.\n";
+    exit(1);
+}
 
 $strParam  = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : $_SERVER['argv'][1];
 $arrConfig = getConfig($strParam);

--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -911,6 +911,9 @@ class FromMySqlToPostgreSql
 
                 if (isset($arrSqlReservedValues[$arrColumn['Default']])) {
                     $sql .= $arrSqlReservedValues[$arrColumn['Default']] . ';';
+                } else if (substr($arrColumn['Type'], 0, 3) === 'bit' && substr($arrColumn['Default'], 0, 2) === "b'") {
+                    // This is a defaultl for a bit column use PostgreSql syntax.
+                    $sql .= substr($arrColumn['Default'], 1) . "::bit;";
                 } else {
                     $sql .= is_numeric($arrColumn['Default'])
                           ? $arrColumn['Default'] . ';'

--- a/migration/FromMySqlToPostgreSql/ViewGenerator.php
+++ b/migration/FromMySqlToPostgreSql/ViewGenerator.php
@@ -58,7 +58,14 @@ class ViewGenerator
                 ('from' == strtolower($arrMySqlViewCode[$i]) || 'join' == strtolower($arrMySqlViewCode[$i])) 
                 && ($i + 1 < $intMySqlViewCodeCount)
             ) {
-                $arrMySqlViewCode[$i + 1] = '"' . $strSchema . '".' . $arrMySqlViewCode[$i + 1];
+                // This code only handles a single set of ( in the code, we assume MySQL outputs the same way always.
+                // Tables might be prefixed by (, so take care of that.
+                $bracketSize = strpos($arrMySqlViewCode[$i + 1], '"');
+                $brackets = $bracketSize == 0 ? '' : substr($arrMySqlViewCode[$i + 1], 0, $bracketSize);
+                $tablename = substr($arrMySqlViewCode[$i + 1], $bracketSize);
+
+                $arrMySqlViewCode[$i + 1] = $brackets . '"' . $strSchema . '".' . $tablename;
+
             }
         }
         

--- a/tests/foreign_key.sql
+++ b/tests/foreign_key.sql
@@ -1,0 +1,37 @@
+drop table if exists zero;
+create table zero (
+ID bigint(20) NOT NULL,
+DATA varchar(255) NOT NULL,
+PRIMARY KEY (ID)
+) ENGINE=InnoDB;
+
+drop table if exists one;
+create table one (
+ID bigint(20) NOT NULL,
+DATA varchar(255) NOT NULL,
+PRIMARY KEY (ID),
+CONSTRAINT one_FK1 FOREIGN KEY (ID) REFERENCES zero (ID)
+) ENGINE=InnoDB;
+
+drop table if exists two;
+create table two (
+ID bigint(20) NOT NULL,
+one_ID bigint(20) NOT NULL,
+DATA varchar(255) NOT NULL,
+PRIMARY KEY (ID),
+CONSTRAINT two_FK1 FOREIGN KEY (one_ID) REFERENCES one (ID)
+) ENGINE=InnoDB;
+
+drop table if exists three;
+create table three (
+ID bigint(20) NOT NULL,
+one_ID bigint(20) NOT NULL,
+DATA varchar(255) NOT NULL,
+PRIMARY KEY (ID),
+CONSTRAINT three_FK1 FOREIGN KEY (one_ID) REFERENCES one (ID)
+) ENGINE=InnoDB;
+
+insert into zero values ( 1, 'One' );
+insert into one values ( 1, 'One' );
+insert into two values ( 1, 1, 'Two' );
+insert into three values ( 1, 1, 'Three' );

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -1,0 +1,50 @@
+-- Invalid copy data from mysql
+DROP TABLE IF EXISTS dates;
+CREATE TABLE dates (field DATE);
+-- INSERT INTO dates VALUES ('0000-00-00');
+-- INSERT INTO dates VALUES ('9999-99-99');
+-- INSERT INTO dates VALUES ('2000-00-00');
+INSERT INTO dates VALUES (NULL);
+INSERT INTO dates VALUES ('2001-01-01');
+
+-- unsigned ints
+DROP TABLE IF EXISTS ints;
+CREATE TABLE ints (field int unsigned);
+INSERT INTO ints VALUES (0);
+INSERT INTO ints VALUES (NULL);
+INSERT INTO ints VALUES (4294967295);
+
+DROP TABLE IF EXISTS bigints;
+CREATE TABLE bigints (field bigint(50) unsigned);
+INSERT INTO bigints VALUES (0);
+INSERT INTO bigints VALUES (NULL);
+INSERT INTO bigints VALUES (18446744073709551615);
+
+-- Bits
+DROP TABLE IF EXISTS bitfield;
+CREATE TABLE bitfield (field bit default b'0');
+INSERT INTO bitfield VALUES (b'0');
+INSERT INTO bitfield VALUES (b'1');
+INSERT INTO bitfield VALUES (NULL);
+
+DROP TABLE IF EXISTS bitfield2;
+CREATE TABLE bitfield2 (field bit(2) default b'01');
+INSERT INTO bitfield2 VALUES (b'00');
+INSERT INTO bitfield2 VALUES (b'01');
+INSERT INTO bitfield2 VALUES (b'10');
+INSERT INTO bitfield2 VALUES (b'11');
+INSERT INTO bitfield2 VALUES (NULL);
+
+-- Fun text
+DROP TABLE IF EXISTS textfield;
+CREATE TABLE textfield (field varchar(255));
+INSERT INTO textfield VALUES ('"\',\\t\\n\\r');
+INSERT INTO textfield VALUES ('interesting field data.');
+INSERT INTO textfield VALUES ('interesting field data.\n');
+INSERT INTO textfield VALUES ('interesting field data.\t');
+
+-- View with brackets
+DROP VIEW IF EXISTS badview;
+CREATE VIEW badview AS SELECT c.field FROM dates a JOIN dates b ON (a.field=b.field) JOIN dates c
+ON (a.field=c.field);
+

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,41 @@
+{
+    "source_description" : [
+        "Connection string to your MySql database",
+        "Please ensure, that you have defined your connection string properly.",
+        "Ensure, that details like 'charset=UTF8' are included in your connection string (if necessary)."
+    ],
+    "source" : "mysql:host=localhost;port=3306;charset=UTF8;dbname=test,root,your_password",
+
+    "target_description" : [
+        "Connection string to your PostgreSql database",
+        "Please ensure, that you have defined your connection string properly.",
+        "Ensure, that details like options='[double dash]client_encoding=UTF8' are included in your connection string (if necessary)."
+    ],
+    "target" : "pgsql:port=5432;dbname=test;options=--client_encoding=UTF8,postgres,your_password",
+
+    "encoding_description" : [
+        "PHP encoding type.",
+        "If not supplied, then UTF-8 will be used as a default."
+    ],
+    "encoding" : "UTF-8",
+
+    "schema_description" : [
+        "schema - a name of the schema, that will contain all migrated tables.",
+        "Default is 'public', which will cause the new tables to appear at the top level of the database defined above in 'target'",
+        "If not supplied, then a new schema will be created automatically."
+    ],
+    "schema" : "public",
+
+    "data_chunk_size_description" : [
+        "During migration each table's data will be split into chunks of data_chunk_size (in MB).",
+        "If not supplied, then 10 MB will be used as a default."
+    ],
+    "data_chunk_size" : 10,
+
+    "data_only_description" : [
+        "Flag, that allows to migrate only the data.",
+        "By default, ti is 0 - entire db-structure + data",
+        "In order to migrate data only - set 1"
+    ],
+    "data_only" : 0
+}


### PR DESCRIPTION
- Test extensions are loaded before starting.
- Enable (( in views to be processed.
- Enable bit field defaults to process.
- Use client buffered copy, so you don't need server privileges or the same computer for it to work.
- Use unbuffered mysql query and chunk sizes for copy, including individual load on error, so large chunks aren't missed, only individual rows.
- Add test files to allow faster checking that operations are working.

A 33Gb database was migrated in 54minutes from MariaDB 10 to PostgreSQL 9.6.    Without error checking and full tables, 25minutes can be acheived.