### PR TITLE
Use ADD CONSTRAINT for unique indexes, resolves #48

### DIFF
--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -1184,11 +1184,20 @@ class FromMySqlToPostgreSql
                     $sql              = 'ALTER TABLE "' . $this->strSchema . '"."' . $strTableName . '" '
                                       . 'ADD PRIMARY KEY(' . implode(',', $arrIndex['column_name']) . ');';
 
+                } else if ($arrIndex['is_unique']) {
+                    // "schema_idxname_{integer}_idx" - is NOT a mistake.
+                    $strColumnName    = str_replace('"', '', $arrIndex['column_name'][0]) . $intCounter;
+                    $strIndexName     = $this->strSchema . '_' . $strTableName . '_' . $strColumnName . '_idx';
+                    $strColumnList    = '(' . implode(',', $arrIndex['column_name']) . ')';
+                    $strCurrentAction = 'uniqueindex';
+                    $sql              = 'ALTER TABLE "' . $this->strSchema . '"."' . $strTableName . '" ADD CONSTRAINT "'
+                                      . $strIndexName . '" UNIQUE '
+                                      . $strColumnList . ";";
                 } else {
                     // "schema_idxname_{integer}_idx" - is NOT a mistake.
                     $strColumnName    = str_replace('"', '', $arrIndex['column_name'][0]) . $intCounter;
                     $strCurrentAction = 'index';
-                    $sql              = 'CREATE ' . ($arrIndex['is_unique'] ? 'UNIQUE ' : '') . 'INDEX "'
+                    $sql              = 'CREATE  INDEX "'
                                       . $this->strSchema . '_' . $strTableName . '_' . $strColumnName . '_idx" ON "'
                                       . $this->strSchema . '"."' . $strTableName . '" ' . $arrIndex['Index_type']
                                       . ' (' . implode(',', $arrIndex['column_name']) . ');';

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -19,6 +19,8 @@ CREATE TABLE bigints (field bigint(50) unsigned);
 INSERT INTO bigints VALUES (0);
 INSERT INTO bigints VALUES (NULL);
 INSERT INTO bigints VALUES (18446744073709551615);
+-- Check unique indexes are moved.
+CREATE UNIQUE INDEX unique_index ON bigints (field);
 
 -- Bits
 DROP TABLE IF EXISTS bitfield;


### PR DESCRIPTION
This is the standard way PostgreSQL does unique indexes,
it includes es the data in the information_schema for easy reference.