### PR TITLE
Ensure binary columns have the same data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ and future developers will be able to confirm that changes don't cause any regre
 
 <h3>PERFORMANCE RESULTS</h3>
 <p>Tested using MariaDB 10 and PostgreSql (9.6).<br />
-The entire process of migration 33Gb MB database (90 tables, approximately 72 million rows),<br />
+The entire process of migration 33 GB database (90 tables, approximately 72 million rows),<br />
 which includes data types mapping, creation of tables, constraints, indexes, <br />
 PKs, FKs, migration of data, garbage-collection and analyzing the newly created <br />
 PostgreSql database took 54 minutes.</p>

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -43,8 +43,16 @@ INSERT INTO textfield VALUES ('interesting field data.');
 INSERT INTO textfield VALUES ('interesting field data.\n');
 INSERT INTO textfield VALUES ('interesting field data.\t');
 
+-- Longblob
+DROP TABLE IF EXISTS blobfield;
+CREATE TABLE blobfield (field longblob);
+INSERT INTO blobfield VALUES ('cat');
+INSERT INTO blobfield VALUES (x'00');
+INSERT INTO blobfield VALUES (x'08');
+INSERT INTO blobfield VALUES (x'0A');
+INSERT INTO blobfield VALUES (x'0D');
+
 -- View with brackets
 DROP VIEW IF EXISTS badview;
 CREATE VIEW badview AS SELECT c.field FROM dates a JOIN dates b ON (a.field=b.field) JOIN dates c
 ON (a.field=c.field);
-


### PR DESCRIPTION
Escaping in MySQL produces hex output by default for a binary
column. That should be inserted into PostgreSQL using the \x
syntax directly to ensure the final result is the same as the source.

Binary was double encoded rather than being decoded and encoded.