### PR TITLE
Migration of spatial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The chunk size can be adjusted easily via configuration file.</li>
 <li> <b>PDO_PGSQL</b> should be installed and enabled </li>
 <li> <b>mbstring</b> should be installed and enabled </li>
 <li> <b>register_argc_argv</b> should be enabled (check php.ini).</li>
+<li> <b>postgis</b> should be installed and enabled to migrate spatial data (geometry type columns).</li>
 </ul>
 
 <h3>USAGE</h3>


### PR DESCRIPTION
In order to successfully migrate columns of type geometry the postgis extension should be installed and enabled otherwise the utility stops working reporting meaningless errors. When I have installed postgis the utility worked like charm without any problems. I think this should be mentioned in the instructions in order to run it successfully in the first attempt. 
Thanks!