### PR TITLE
[TASK] Make script compatible with PHP 7+

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,70 +20,79 @@
 
 /**
  * Retrieves a congiguration data, and converts it to an array.
- * 
- * @param  string $strPath
+ *
+ * @param string $strPath
  * @return array
  */
 function getConfig($strPath)
 {
     $arrRetVal = [];
-    
+
+    if(empty($strPath)) {
+        $strPath = __DIR__ . '/config.json';
+    }
+
     if (is_file($strPath)) {
         $strExtension = pathinfo($strPath, PATHINFO_EXTENSION);
-        
-        switch ($strExtension) {
-            case 'json':
-                $strContents = file_get_contents($strPath);
-                $config      = json_decode($strContents, true);
-                $strError    = '';
-                
-                switch (json_last_error()) {
-                    case JSON_ERROR_NONE:
-                        // No code should be put here.
-                        break;
-                    
-                    case JSON_ERROR_DEPTH:
-                        $strError = 'Maximum stack depth exceeded';
-                        break;
-                    
-                    case JSON_ERROR_STATE_MISMATCH:
-                        $strError = 'Underflow or the modes mismatch';
-                        break;
-                    
-                    case JSON_ERROR_CTRL_CHAR:
-                        $strError = 'Unexpected control character found';
-                        break;
-                    
-                    case JSON_ERROR_SYNTAX:
-                        $strError = 'Syntax error, malformed JSON';
-                        break;
-                    
-                    case JSON_ERROR_UTF8:
-                        $strError = 'Malformed UTF-8 characters, possibly incorrectly encoded';
-                        break;
-                    
-                    default:
-                        $strError = 'Unknown error';
-                        break;
-                }
-                
-                $arrRetVal = is_null($config) || !empty($strError) ? [] : $config;
-                break;
-            
-            case 'xml':
-                $config    = simplexml_load_file($strPath);
-                $arrRetVal = empty($config) ? [] : get_object_vars($config);
-                break;
-        }
     }
-    
+
+    switch ($strExtension) {
+
+
+        case 'xml':
+            $config = simplexml_load_file($strPath);
+            $arrRetVal = empty($config) ? [] : get_object_vars($config);
+            break;
+        case 'json':
+        default:
+            $strContents = file_get_contents($strPath);
+            $config = json_decode($strContents, true);
+            $strError = '';
+
+            switch (json_last_error()) {
+                case JSON_ERROR_NONE:
+                    // No code should be put here.
+                    break;
+
+                case JSON_ERROR_DEPTH:
+                    $strError = 'Maximum stack depth exceeded';
+                    break;
+
+                case JSON_ERROR_STATE_MISMATCH:
+                    $strError = 'Underflow or the modes mismatch';
+                    break;
+
+                case JSON_ERROR_CTRL_CHAR:
+                    $strError = 'Unexpected control character found';
+                    break;
+
+                case JSON_ERROR_SYNTAX:
+                    $strError = 'Syntax error, malformed JSON';
+                    break;
+
+                case JSON_ERROR_UTF8:
+                    $strError = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                    break;
+
+                default:
+                    $strError = 'Unknown error';
+                    break;
+            }
+
+            $arrRetVal = is_null($config) || !empty($strError) ? [] : $config;
+            break;
+    }
+
+
     return $arrRetVal;
 }
+
+ini_set('display_errors', 'on');
 
 // Verify the extensions are loaded before running.
 if (!extension_loaded('pgsql')) {
     echo "Postgresql not enabled: you need the 'pgsql' module.\n";
-    exit(1);
+    //exit(1);
 }
 if (!extension_loaded('pdo_mysql')) {
     echo "Postgresql not enabled: you need the 'pdo_mysql' module.\n";
@@ -99,24 +108,24 @@ if (!extension_loaded('mbstring')) {
 }
 if (ini_get('register_argc_argv') == 0) {
     echo "register_argc_argv is not turned on, we can't process command line arguments.\n";
-    exit(1);
+    //exit(1);
 }
 
-$strParam  = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : $_SERVER['argv'][1];
+$strParam = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : $_SERVER['argv'][1];
 $arrConfig = getConfig($strParam);
 unset($strParam);
 
 if (empty($arrConfig)) {
     echo PHP_EOL, '-- Cannot perform a migration due to missing "config[.xml | .json]" file.', PHP_EOL;
 } else {
-    spl_autoload_register(function($class) {
+    spl_autoload_register(function ($class) {
         require_once 'migration/FromMySqlToPostgreSql/' . $class . '.php';
     });
-    
+
     $arrConfig['temp_dir_path'] = __DIR__ . '/temporary_directory';
     $arrConfig['logs_dir_path'] = __DIR__ . '/logs_directory';
-    
-    $migration = new \FromMySqlToPostgreSql($arrConfig);
+
+    $migration = new FromMySqlToPostgreSql($arrConfig);
     $migration->migrate();
 }
 

--- a/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
+++ b/migration/FromMySqlToPostgreSql/FromMySqlToPostgreSql.php
@@ -1616,7 +1616,7 @@ class FromMySqlToPostgreSql
          * Create a database schema.
          */
         if (!$this->createSchema()) {
-            $this->log('-- Script is terminated.' . PHP_EOL);
+            $this->log('-- Script is terminated. Could not create schema' . PHP_EOL);
             exit;
         } else {
             $this->log('-- New schema "' . $this->strSchema . '" was successfully created...' . PHP_EOL);


### PR DESCRIPTION
I was migrating from MySQL to PostgreSQL ans couldn't find a single tool that worked nearly correctly until I stumbled upon this script.

This clearly deserves more visibility, but that's not the point of my PR.

As I was trying to make it work, I crossed some issues that I adressed directly (these are all quickfixes, none of them are proper fixes and nothing is properly documented):
1. The script asks for mysql, which is deprecated, so I removed the exit, since we work with PDO for MySQL anyway
2. The script asks for pgsql extension, which is also deprecated and not used since we work with PDO for PostgreSQL
3. The ini option for argc and argv is not needed anymore, so I removed the exit there too
4. Since I was running the script on a frontend side first and not on cli, I had to have a fallback that worked in any case so I moved some stuff around for the configuration, so that by default the script would look for config.json in its current directory and remodelled the switch case
5. The script stopped saying "Script is terminated." without further information, so I added the information on why it stopped (at least the first time I came accross it).

I hope you'll consider accepting my PR and maybe want to work on this script some more for even further improvements (and since PHP 7.4 is out, I think there would be some nice improvements that you could make, just for the sake of it) and even publishing it on composer.

Best Regards
Tizian